### PR TITLE
Fix postgres healthcheck causing errors in log

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     image: timescale/timescaledb:latest-pg14
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      test: ["CMD-SHELL", 'pg_isready -U "$$POSTGRES_USER"']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     image: timescale/timescaledb:latest-pg14
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
pg_isready will use the current user to query the database, which
is the root user. This user does not exist in the database, which
causes "FATAL:  role "root" does not exist" to be logged every
time the healthcheck is run.

This commit fixes this issue with the -U flag to specify the user.
Note the $$ENV synax, see here for more info:
https://docs.docker.com/compose/environment-variables/