### PR TITLE
Fix mariadb healthcheck causing [Warning] Access denied for user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     image: mariadb:10.7.1
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      test: [ "CMD-SHELL", 'mysqladmin ping --user "$$MYSQL_USER" --password="$$MYSQL_PASSWORD"' ]
       timeout: 20s
       retries: 10
     ports:


### PR DESCRIPTION
mysqladmin by default connects to localhost with the current user
(which is root) without a password. Not specifying
the correct user and password causes the warning.

A shell must be used for the healthcheck to grab the username
and password from the environment.