### PR TITLE
Lengthen all reinforcement maturation times

### DIFF
--- a/paper/config/plugins/Citadel/config.yml
+++ b/paper/config/plugins/Citadel/config.yml
@@ -41,8 +41,8 @@ reinforcements:
       speed: 0.04
       particleCount: 80
       offset: 0.0
-    mature_time: 5m
-    acid_time: 20m
+    mature_time: 1h
+    acid_time: 2h
     acid_priority: 2
     name: Stone
     hit_points: 50
@@ -69,8 +69,8 @@ reinforcements:
       speed: 0.04
       particleCount: 80
       offset: 0.0
-    mature_time: 5m
-    acid_time: 20m
+    mature_time: 1h
+    acid_time: 2h
     acid_priority: 2
     name: Netherbrick
     hit_points: 50
@@ -97,8 +97,8 @@ reinforcements:
       speed: 0.13
       particleCount: 200
       offset: 0
-    mature_time: 30m
-    acid_time: 6h
+    mature_time: 8h
+    acid_time: 12h
     acid_priority: 5
     name: Iron
     hit_points: 300
@@ -125,8 +125,8 @@ reinforcements:
       speed: 0.13
       particleCount: 200
       offset: 0
-    mature_time: 30m
-    acid_time: 6h
+    mature_time: 8h
+    acid_time: 12h
     acid_priority: 5
     name: Gold
     hit_points: 300
@@ -153,8 +153,8 @@ reinforcements:
       speed: 0.5
       particleCount: 500
       offset: 0.1
-    mature_time: 4h
-    acid_time: 48h
+    mature_time: 24h
+    acid_time: 36h
     acid_priority: 10
     name: Diamond
     hit_points: 2000
@@ -181,8 +181,8 @@ reinforcements:
       speed: 0.5
       particleCount: 500
       offset: 0.1
-    mature_time: 4h
-    acid_time: 48h
+    mature_time: 24h
+    acid_time: 36h
     acid_priority: 10
     name: GildedBlackstone
     hit_points: 2000


### PR DESCRIPTION
Reinforcement times across the board are far too short.

It is completely nonsensical that structures built can rival the strength of buildings that have stood for months after just 5 minutes or an hour. It sucks the fun out of civ knowing you have mere seconds to log in and remove stone-reinforced grief before having to use acid blocks instead. It is completely counterproductive for those with lives outside of civ to always be an hour away from being totally invalidated. The stale vault meta is only bolstered by the fact that vault spikes are risk-free and diamond reinforced expansions can be erected overnight.

A lot of people are scared of big maturation numbers but forget they don't represent 'time until viable'. Just a few seconds after SRO is placed, it doubles in strength. The time it takes to mine it then allows it to mature further. Pardon my French, but it is absolutely FUCKED that you can be mining a block and the amount of breaks it will take to destroy it is INCREASING while you're ACTIVELY BREAKING IT.

"but my skybridging": what do you want to be more important, the skybridge or the people fighting in it?

"but my build might be broken overnight": just 15 minutes after you place a stone reinforced block, it will already take 16 hits to break. unless you're building in a warzone, you're going to be fine.

"but my acids will take longer": maybe now it will be actually viable to break blocks still maturing instead of giving up and going straight for acid.

"but my bunker pvp": I've seen bunker pvp on this iteration and it's fair to say I think the vast majority of people hate the stone reinforced obby/trapdoors/doors/buttons spam meta.

"but it will encourage camping to abuse when reinforcements are maturing": but this ALREADY HAPPENS, just the other way around. Players literally wait for people to be offline to spam reinforcements before they log on again. Turning this around to favour the breaker's side is more healthy.

"but now obbybombing is less viable": good.