### PR TITLE
Fix a small mistake in the Gold Forge pickaxe table

### DIFF
--- a/paper/config/plugins/FactoryMod/config.yml
+++ b/paper/config/plugins/FactoryMod/config.yml
@@ -7525,9 +7525,6 @@ recipes:
             ub:
               enchant: unbreaking
               level: 3
-            for:
-              enchant: fortune
-              level: 3
             eff:
               enchant: efficiency
               level: 5


### PR DESCRIPTION
The Ub3 E5 pickaxe has a fortune enchant that shouldn't be there (making it a double of the Ub3 E5 F3 pick)