### PR TITLE
Change Dark prismarine to use black dye.

### DIFF
--- a/paper/config/plugins/FactoryMod/config.yml
+++ b/paper/config/plugins/FactoryMod/config.yml
@@ -1776,8 +1776,8 @@ recipes:
       prismarine:
         material: PRISMARINE
         amount: 64
-      ink:
-        material: INK_SAC
+      Black_dye:
+        material: BLACK_DYE
         amount: 4
     output:
       dark_prismarine:


### PR DESCRIPTION
Just changing the Dark prismarine recipe to use black dye instead of inc sacs to make it consistent with other "dyeing" recipes.