### PR TITLE
Add Discord to multi-account/VPN ban reason.

### DIFF
--- a/paper/config/plugins/BanStick/config.yml
+++ b/paper/config/plugins/BanStick/config.yml
@@ -72,10 +72,10 @@ log:
 events:
   proxy:
     threshold: 2.8
-    banMessage: VPS / VPN Proxy use is generally prohibited. Issue a ticket at support in the CivMC Discord. Or modmail to www.reddit.com/r/CivMC to discuss.
+    banMessage: VPS / VPN Proxy use is generally prohibited. Issue a ticket at support in the CivMC Discord to discuss: https://discord.gg/nDnsU6vJqg
   share:
     threshold: 0
-    banMessage: Multiaccounting is not generally allowed. Issue a ticket at support in the CivMC Discord. Or modmail to www.reddit.com/r/CivMC to resolve/discuss.
+    banMessage: Multiaccounting is not generally allowed. Issue a ticket at support in the CivMC Discord to discuss/resolve: https://discord.gg/nDnsU6vJqg
   enable:
     ipBans: true
     subnetBans: true
@@ -98,7 +98,7 @@ proxy:
     defaultScore: 3.0
     ban:
       length: 163800000
-      message: VPS / VPN Proxy use is generally prohibited. Issue a ticket at support in the CivMC Discord. Or modmail to www.reddit.com/r/CivMC to discuss.
+      message: VPS / VPN Proxy use is generally prohibited. Issue a ticket at support in the CivMC Discord to discuss: https://discord.gg/nDnsU6vJqg
     url: https://raw.githubusercontent.com/client9/ipcat/master/datacenters.csv
     period: 576000
     delay: 4200

--- a/paper/config/plugins/BanStick/config.yml
+++ b/paper/config/plugins/BanStick/config.yml
@@ -72,10 +72,10 @@ log:
 events:
   proxy:
     threshold: 2.8
-    banMessage: VPS / VPN Proxy use is generally prohibited. Modmail to www.reddit.com/r/CivMC to discuss
+    banMessage: VPS / VPN Proxy use is generally prohibited. Issue a ticket at support in the CivMC Discord. Or modmail to www.reddit.com/r/CivMC to discuss.
   share:
     threshold: 0
-    banMessage: Multiaccounting is not generally allowed. To discuss or if in error, modmail www.reddit.com/r/CivMC
+    banMessage: Multiaccounting is not generally allowed. Issue a ticket at support in the CivMC Discord. Or modmail to www.reddit.com/r/CivMC to resolve/discuss.
   enable:
     ipBans: true
     subnetBans: true
@@ -98,7 +98,7 @@ proxy:
     defaultScore: 3.0
     ban:
       length: 163800000
-      message: VPS / VPN Proxy use is generally prohibited. Modmail to www.reddit.com/r/CivMC to discuss
+      message: VPS / VPN Proxy use is generally prohibited. Issue a ticket at support in the CivMC Discord. Or modmail to www.reddit.com/r/CivMC to discuss.
     url: https://raw.githubusercontent.com/client9/ipcat/master/datacenters.csv
     period: 576000
     delay: 4200


### PR DESCRIPTION
Since most VPN and Multi-account bans are now handled via discord it's good to update the ban message to reflect that and propose it as an option.