### PR TITLE
Correct vote times.

### DIFF
--- a/paper/config/plugins/EssenceGlue/config.yml
+++ b/paper/config/plugins/EssenceGlue/config.yml
@@ -27,7 +27,7 @@ voting_reward:
 
 voting_sites:
   minecraftmp:
-    voting_cooldown: 20 hours
+    voting_cooldown: 24 hours
     voting_url: 'https://minecraft-mp.com/server/305231/vote/?username=%PLAYER%'
     internal_key: 'Minecraft-MP.com'
     name: 'minecraft-mp.com'
@@ -37,7 +37,7 @@ voting_sites:
     internal_key: 'MCSL'
     name: 'minecraft-server-list.com'
   minecraftservers:
-    voting_cooldown: 20 hours
+    voting_cooldown: 24 hours
     voting_url: 'https://minecraftservers.org/vote/636677'
     internal_key: 'MinecraftServers.org'
     name: 'minecraftservers.org'


### PR DESCRIPTION
The time for these 2 is not 20 hours but 24.
At the moment they show up as available to vote, while actually you still have to wait 4 hours.