### PR TITLE
Increase starting pearl costs, and increase the speed at which costs increase.

### DIFF
--- a/paper/config/plugins/ExilePearl/config.yml
+++ b/paper/config/plugins/ExilePearl/config.yml
@@ -268,11 +268,11 @@ pearls:
   decay_interval_human: day
   decay_interval_min_human: 34560 #This is hardcoded to divide by 1440 so we have to multiply by 24 to show the correct pearl cost
   decay_interval_min: 60
-  decay_amount: 1
+  decay_amount: 7
   decay_timeout_min: 525600 # don't timeout until after a year
-  start_value: 48 #starting pearl health is 2 days
-  max_value: 336 #maximum pearl health is 14 days
-  cost_multiplier_days: 90 #increase pearl repair cost after 90 days
+  start_value: 336 #starting pearl health is 2 days
+  max_value: 2352 #maximum pearl health is 14 days
+  cost_multiplier_days: 21 #increase pearl repair cost after 21 days
   repair_materials:
     PRISON:
      mana:
@@ -280,7 +280,7 @@ pearls:
        name: Player Essence
        lore:
          - Activity reward used to fuel pearls                                                      
-       repair: 12 #24 health is consumed per day, so two essence fuelds one pearl for a day
+       repair: 24 #168 health is consumed per day, so seven essence fuels one pearl for a day
 #    EXILE:
 #      mana:                         
 #        material: ENDER_EYE    

--- a/paper/config/plugins/ExilePearl/config.yml
+++ b/paper/config/plugins/ExilePearl/config.yml
@@ -271,7 +271,7 @@ pearls:
   decay_amount: 7
   decay_timeout_min: 525600 # don't timeout until after a year
   start_value: 336 #starting pearl health is 2 days
-  max_value: 2352 #maximum pearl health is 14 days
+  max_value: 17040 #maximum pearl health is 14 days
   cost_multiplier_days: 21 #increase pearl repair cost after 21 days
   repair_materials:
     PRISON:


### PR DESCRIPTION
Increase decay amount to 7 per interval. Increase starting value and maximum value proportionally so as not to effect them. Decrease cost multiplier to 21 so that pearl cost increases more quickly. Increase repair cost to 24, so that the starting repair cost is 7 essence per day up from 2.