### PR TITLE
blocksToErode=-1 to discourage overlapping

### DIFF
--- a/paper/config/plugins/Bastion/config.yml
+++ b/paper/config/plugins/Bastion/config.yml
@@ -34,7 +34,7 @@ bastions:
     warmupTime: 86400000
     erosionPerDay: 0
     regenPerDay: 0
-    blocksToErode: 1
+    blocksToErode: -1
     placementCooldown: 2000
     destroyOnRemove: true
     onlyDirectDestroy: false
@@ -69,7 +69,7 @@ bastions:
     warmupTime: 86400000
     erosionPerDay: 0
     regenPerDay: 0
-    blocksToErode: 1
+    blocksToErode: -1
     placementCooldown: 2000
     destroyOnRemove: false
     onlyDirectDestroy: true
@@ -104,7 +104,7 @@ bastions:
     warmupTime: 86400000
     erosionPerDay: 0
     regenPerDay: 0
-    blocksToErode: 1
+    blocksToErode: -1
     placementCooldown: 2000
     destroyOnRemove: true
     onlyDirectDestroy: false


### PR DESCRIPTION
blocksToErode behaviour is defined here:
https://github.com/CivMC/Bastion/blob/c9b709f4ac56517d981aec5119bf33f023fc435a/paper/src/main/java/isaac/bastion/manager/BastionBlockManager.java#L113 

Setting blocksToErode=1 means 1 randomly chosen bastion from overlapping bastions takes damage per place, while blocksToErode<0 means all bastions from overlapping bastions take damage. 

This was the case in Devoted and was also the case in CivClassic, but default Bastion config.yml has blocksToErode=1.
https://github.com/CivClassic/AnsibleSetup/blob/master/templates/public/plugins/Bastion/config.yml.j2

Will make PR in Bastion plugin to reflect the standard of discouraging overlap.