### PR TITLE
Lower Stone&Iron acid maturation times

### DIFF
--- a/paper/config/plugins/Citadel/config.yml
+++ b/paper/config/plugins/Citadel/config.yml
@@ -42,7 +42,7 @@ reinforcements:
       particleCount: 80
       offset: 0.0
     mature_time: 30m
-    acid_time: 2h
+    acid_time: 30m
     acid_priority: 2
     name: Stone
     hit_points: 50
@@ -70,7 +70,7 @@ reinforcements:
       particleCount: 80
       offset: 0.0
     mature_time: 30m
-    acid_time: 2h
+    acid_time: 30m
     acid_priority: 2
     name: Netherbrick
     hit_points: 50

--- a/paper/config/plugins/Citadel/config.yml
+++ b/paper/config/plugins/Citadel/config.yml
@@ -98,7 +98,7 @@ reinforcements:
       particleCount: 200
       offset: 0
     mature_time: 4h
-    acid_time: 12h
+    acid_time: 6h
     acid_priority: 5
     name: Iron
     hit_points: 300
@@ -126,7 +126,7 @@ reinforcements:
       particleCount: 200
       offset: 0
     mature_time: 4h
-    acid_time: 12h
+    acid_time: 6h
     acid_priority: 5
     name: Gold
     hit_points: 300


### PR DESCRIPTION
Lower them back down from 2 hours for gold 4 hours for diamond and 8 hours for netherite acid blocks To 30 min, 1 hour and 2 hours respectively.

This is still higher than before the previous change, (10 min) But not so high that acid is practically useless on stone as is currently.