### PR TITLE
Nether smelter creation/repair cost update & red nether bricks recipe update

### DIFF
--- a/paper/config/plugins/FactoryMod/config.yml
+++ b/paper/config/plugins/FactoryMod/config.yml
@@ -1607,9 +1607,21 @@ recipes:
         material: NETHERRACK
         amount: 64
     output:
-      netherbrick:
+      netherbricks:
         material: NETHER_BRICKS
         amount: 64
+  make_nether_brick_fence:
+    production_time: 4s
+    name: Make Fences
+    type: PRODUCTION
+    input:
+      netherrack:
+        material: NETHERRACK
+        amount: 16
+    output:
+      fence:
+        material: NETHER_BRICK_FENCE
+        amount: 128
   smelt_red_netherbrick:
     forceInclude: true
     production_time: 4s


### PR DESCRIPTION
- Change the creation/repair material of the nether smelter to netherbricks instead of netherbrick, this is more consistent with the design of the basic smelter as the factory will now produce the material used to repair it. The change in amount is so that the initial creation still requires you to smelt 8 stacks of netherrack, inline with the 8 stacks of cobble that need to be smelted for the basic smelter.

- Change the red_nether_brick recipe so that it gives the same bonus to production as the nether_brick recipe. Currently, it gives 0 bonus to production on vanilla costs, whereas the nether_brick recipe gives 4x greater output than vanilla.