### PR TITLE
Corrected TemporalIsles/TemportalEmpire

### DIFF
--- a/paper/config/plugins/RandomSpawn/worlds.yml
+++ b/paper/config/plugins/RandomSpawn/worlds.yml
@@ -184,6 +184,22 @@ world:
       nearby: true # require another player nearby?
       checkradius: 900 # require another player closer than this
       radius: 200 # spawn area outer radius
+      exclusion: 0 # spawn area inner radius 
+    Kaowta: # plrog
+      x: -8132
+      y: 250 # overridden in code, but must be set
+      z: -139
+      nearby: true # require another player nearby?
+      checkradius: 900 # require another player closer than this
+      radius: 200 # spawn area outer radius
+      exclusion: 0 # spawn area inner radius
+    Kingdom of Amicitia: # jjonnn
+      x: 702
+      y: 250 # overridden in code, but must be set
+      z: 3732
+      nearby: true # require another player nearby?
+      checkradius: 900 # require another player closer than this
+      radius: 200 # spawn area outer radius
       exclusion: 0 # spawn area inner radius
     Lambat: # Kaprediem#3161
       x: 3651
@@ -285,14 +301,6 @@ world:
       x: 2950
       y: 250 # overridden in code, but must be set
       z: -5550
-      nearby: true # require another player nearby?
-      checkradius: 900 # require another player closer than this
-      radius: 200 # spawn area outer radius
-      exclusion: 0 # spawn area inner radius
-    TemporalEmpire: # PhysicsGamer
-      x: -850
-      y: 250 # overridden in code, but must be set
-      z: -5900
       nearby: true # require another player nearby?
       checkradius: 900 # require another player closer than this
       radius: 200 # spawn area outer radius

--- a/paper/config/plugins/RandomSpawn/worlds.yml
+++ b/paper/config/plugins/RandomSpawn/worlds.yml
@@ -129,6 +129,14 @@ world:
       checkradius: 900 # require another player closer than this
       radius: 200 # spawn area outer radius
       exclusion: 0 # spawn area inner radius
+    Hell: # .byhalia
+      x: -1821
+      y: 250 # overridden in code, but must be set
+      z: 2496
+      nearby: true # require another player nearby?
+      checkradius: 900 # require another player closer than this
+      radius: 200 # spawn area outer radius
+      exclusion: 0 # spawn area inner radius
     HyperboreanConfederation: # SpacemanSpleef#0212
       x: -880
       y: 250 # overridden in code, but must be set
@@ -281,10 +289,26 @@ world:
       checkradius: 900 # require another player closer than this
       radius: 200 # spawn area outer radius
       exclusion: 0 # spawn area inner radius
-    TemporalIsles: # PhysicsGamer
+    TemporalEmpire: # PhysicsGamer
       x: -850
       y: 250 # overridden in code, but must be set
       z: -5900
+      nearby: true # require another player nearby?
+      checkradius: 900 # require another player closer than this
+      radius: 200 # spawn area outer radius
+      exclusion: 0 # spawn area inner radius
+    TemporalIsles: # dr_bacon_hair
+      x: -1808
+      y: 250 # overridden in code, but must be set
+      z: -5851
+      nearby: true # require another player nearby?
+      checkradius: 900 # require another player closer than this
+      radius: 200 # spawn area outer radius
+      exclusion: 0 # spawn area inner radius
+    The Papal States: # Antares
+      x: -6700
+      y: 250 # overridden in code, but must be set
+      z: 625
       nearby: true # require another player nearby?
       checkradius: 900 # require another player closer than this
       radius: 200 # spawn area outer radius
@@ -341,22 +365,6 @@ world:
       x: 5917
       y: 250 # overridden in code, but must be set
       z: -2257
-      nearby: true # require another player nearby?
-      checkradius: 900 # require another player closer than this
-      radius: 200 # spawn area outer radius
-      exclusion: 0 # spawn area inner radius
-    The Papal States: # Antares
-      x: -6700
-      y: 250 # overridden in code, but must be set
-      z: 625
-      nearby: true # require another player nearby?
-      checkradius: 900 # require another player closer than this
-      radius: 200 # spawn area outer radius
-      exclusion: 0 # spawn area inner radius
-    Hell: # .byhalia
-      x: -1821
-      y: 250 # overridden in code, but must be set
-      z: 2496
       nearby: true # require another player nearby?
       checkradius: 900 # require another player closer than this
       radius: 200 # spawn area outer radius


### PR DESCRIPTION
Renamed TemporalIsles to TemportalEmpire and added actual TemporalIsles. Also reordered to be in alphabetical order again.